### PR TITLE
Allow configuration of default root keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ log4j.appender.STDOUT.layout.UserFields=field1:val1,field2:val2
 log4j.appender.STDOUT.layout.FormatFn=your-namespace.core/fancy-format
 ```
 
+## Root Key Prefixes
+
+Some keys emitted by default such as `:file`, `:method`, `:class`,
+etc., may clash with keys you wish to emit from software. A prefix to
+the default root keys can be set so as not to conflict with
+application keys.
+
+``` ini
+log4j.appender.STDOUT.layout.RootKeyPrefix=java
+```
+
 ## Env
 
 You can set `$APPLICATION` and/or `$TEAM` in your environment. This


### PR DESCRIPTION
Allow default root keys to be emitted with a user configurable prefix.

Some keys emitted by default such as `:file`, `:method`, `:class`, etc., may clash with keys you wish to emit from software. This pull-request introduces a prefix to the default root keys can be set so as not to conflict with user emitted application keys.
