### PR TITLE
Fix dependency issues

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -22,7 +22,7 @@
  push {:repo "clojars"})
 
 (boot/deftask build []
-  (comp (pom) (jar)))
+  (comp (aot :namespace '#{log4-clj-layout.layout}) (pom) (jar)))
 
 (boot/deftask deploy []
   (comp (build) (install) (push)))

--- a/build.boot
+++ b/build.boot
@@ -13,7 +13,8 @@
 (require '[boot.core :as boot])
 
 (set-env! :repositories 
-          [["clojars" {:url "https://clojars.org/repo/"
+          [["central" {:url "https://repo1.maven.org/maven2"}]
+           ["clojars" {:url "https://clojars.org/repo/"
                        :username (System/getenv "CLOJARS_USER")
                        :password (System/getenv "CLOJARS_PASS")}]])
 


### PR DESCRIPTION
This fixes an issue introduced in `0.1.7` where the jar would be empty, because the `aot` instruction was removed.

This adds maven central as an explicit source for jar files, otherwise boot fails to revolve dependencies, not available in clojars.